### PR TITLE
Need to use environment mode to prevent changes to Loki resources in development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     }
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "APP_ENV=development vite",
     "build": "vite build",
-    "serve": "vite preview",
+    "serve": "APP_ENV=development vite preview",
     "test:unit": "jest --config=jest.unit.config.js",
     "loki": "node uploadToLoki.js"
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -51,3 +51,38 @@ export interface ServiceOutput {
     oldContentType: string;
     maxAge: string;
 }
+
+export interface QueryDataObject {
+    urn: string;
+    name: string;
+    summary: string;
+    queryString: string;
+    securityFunctionUrns: string[];
+    boundToEntityTypeUrn?: string;
+    childQueries: ChildQuery[];
+    inactive: boolean;
+    createDate: string;
+    createByUrn: string;
+    lastEditDate: string;
+    lastEditByUrn: string;
+    queryEngineUrn: string;
+    dataSpaceUrn: string;
+    queryParams: QueryParam[];
+}
+
+export interface ChildQuery {
+    urn: string;
+    queryString: string;
+    dataSpaceUrn: string;
+    queryParams?: QueryParam[];
+}
+
+export interface QueryParam {
+    codeName: string;
+    valueTypeUrn:
+        | "urn:com:loki:core:model:types:string"
+        | "urn:com:loki:core:model:types:bool"
+        | "urn:com:loki:core:model:types:integer"
+        | "urn:com:loki:core:model:types:date"
+        | "urn:com:loki:core:model:types:decimal";
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,19 +10,19 @@ const { resolve } = require("path");
  * @type {import('vite').UserConfig}
  */
 const viteConfig = {
-    root: "./",
-    plugins:
+  root: "./",
+  plugins:
         process.env.APP_ENV === "development"
-            ? [vue()]
-            : [fixLokiRefs(), vue()],
-    build: {
-        rollupOptions: {
-            input: {
-                main: resolve(__dirname, "index.html"),
-            },
-        },
-        outDir: "dist",
-        assetsDir: "./",
+          ? [vue()]
+          : [fixLokiRefs(), vue()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, "index.html"),
+      },
     },
+    outDir: "dist",
+    assetsDir: "./",
+  },
 };
 export default defineConfig(viteConfig);

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,22 +4,25 @@ import { defineConfig } from "vite";
 
 import { fixLokiRefs } from "./fixLokiRefs";
 
-const { resolve } = require('path');
+const { resolve } = require("path");
 
 /**
  * @type {import('vite').UserConfig}
  */
 const viteConfig = {
-  root: './',
-  plugins: [fixLokiRefs(), vue()],
-  build: {
-    rollupOptions: {
-      input: {
-        main: resolve(__dirname, 'index.html'),
-      },
+    root: "./",
+    plugins:
+        process.env.APP_ENV === "development"
+            ? [vue()]
+            : [fixLokiRefs(), vue()],
+    build: {
+        rollupOptions: {
+            input: {
+                main: resolve(__dirname, "index.html"),
+            },
+        },
+        outDir: "dist",
+        assetsDir: "./",
     },
-    outDir: 'dist',
-    assetsDir: './',
-  },
 };
 export default defineConfig(viteConfig);


### PR DESCRIPTION
@andrewhwaller @andrew-waller I couldn't get the local copy to load the bundled resources if the `fixLokiRefs` plugin had altered `index.html`. I added an explicit `APP_ENV` variable to the scripts in `package.json` to **prevent** alteration of `index.html` if running in local mode. 